### PR TITLE
Fluxes and heating rates by spectral band are now optionally calculated.

### DIFF
--- a/climt/_components/rrtmg/lw/component.py
+++ b/climt/_components/rrtmg/lw/component.py
@@ -156,11 +156,36 @@ class RRTMGLongwave(TendencyComponent):
             'dims': ['mid_levels', '*'],
             'units': 'degK day^-1',
         },
+        'upwelling_longwave_flux_by_band_in_air': {
+            'dims': ['interface_levels', '*'],
+            'units': 'W m^-2',
+        },
+        'downwelling_longwave_flux_by_band_in_air': {
+            'dims': ['interface_levels', '*'],
+            'units': 'W m^-2',
+        },
+        'upwelling_longwave_flux_by_band_in_air_assuming_clear_sky': {
+            'dims': ['interface_levels', '*'],
+            'units': 'W m^-2',
+        },
+        'downwelling_longwave_flux_by_band_in_air_assuming_clear_sky': {
+            'dims': ['interface_levels', '*'],
+            'units': 'W m^-2',
+        },
+        'air_temperature_tendency_from_longwave_by_band_assuming_clear_sky': {
+            'dims': ['mid_levels', '*'],
+            'units': 'degK day^-1',
+        },
+        'air_temperature_tendency_from_longwave_by_band': {
+            'dims': ['mid_levels', '*'],
+            'units': 'degK day^-1',
+        },
     }
 
     def __init__(
             self,
             calculate_change_up_flux=False,
+            calculate_fluxes_by_band=False,
             cloud_overlap_method=None,
             cloud_optical_properties='liquid_and_ice_clouds',
             cloud_ice_properties='ebert_curry_two',
@@ -178,6 +203,11 @@ class RRTMGLongwave(TendencyComponent):
                 surface temperature alone. Can be used to adjust fluxes in between radiation calls
                 only due to change of surface temperature. Default value is :code:`False`, meaning this quantity
                 is not calculated.
+
+            calculate_fluxes_by_band (bool):
+                calculate radiative fluxes and heating rates in each spectral band in addition to the net
+                radiative fluxes and heating rates. Default value is :code:`False`, meaning that only the net fluxes
+                and heating rates are calculated.
 
             cloud_overlap_method (string):
                 Choose the method to do overlap with:
@@ -248,6 +278,11 @@ class RRTMGLongwave(TendencyComponent):
             self._calc_dflxdt = 1
         else:
             self._calc_dflxdt = 0
+        
+        if calculate_fluxes_by_band:
+            self._calc_flxbnd = 1
+        else:
+            self._calc_flxbnd = 0
 
         self._mcica = mcica
         if mcica:
@@ -311,6 +346,7 @@ class RRTMGLongwave(TendencyComponent):
                 self._Cpd,
                 self._cloud_overlap,
                 self._calc_dflxdt,
+                self._calc_flxbnd,
                 self._cloud_optics,
                 self._ice_props,
                 self._liq_props)
@@ -418,6 +454,12 @@ class RRTMGLongwave(TendencyComponent):
                 diagnostics['upwelling_longwave_flux_in_air_assuming_clear_sky'],
                 diagnostics['downwelling_longwave_flux_in_air_assuming_clear_sky'],
                 diagnostics['air_temperature_tendency_from_longwave_assuming_clear_sky'],
+                diagnostics['upwelling_longwave_flux_by_band_in_air'],
+                diagnostics['downwelling_longwave_flux_by_band_in_air'],
+                diagnostics['air_temperature_tendency_from_longwave_by_band'],,
+                diagnostics['upwelling_longwave_flux_by_band_in_air_assuming_clear_sky'],
+                diagnostics['downwelling_longwave_flux_by_band_in_air_assuming_clear_sky'],
+                diagnostics['air_temperature_tendency_from_longwave_by_band_assuming_clear_sky'],
                 state['longwave_optical_thickness_due_to_cloud'],
                 state['mass_content_of_cloud_ice_in_atmosphere_layer'],
                 state['mass_content_of_cloud_liquid_water_in_atmosphere_layer'],
@@ -459,6 +501,12 @@ class RRTMGLongwave(TendencyComponent):
                 diagnostics['upwelling_longwave_flux_in_air_assuming_clear_sky'],
                 diagnostics['downwelling_longwave_flux_in_air_assuming_clear_sky'],
                 diagnostics['air_temperature_tendency_from_longwave_assuming_clear_sky'],
+                diagnostics['upwelling_longwave_flux_by_band_in_air'],
+                diagnostics['downwelling_longwave_flux_by_band_in_air'],
+                diagnostics['air_temperature_tendency_from_longwave_by_band'],,
+                diagnostics['upwelling_longwave_flux_by_band_in_air_assuming_clear_sky'],
+                diagnostics['downwelling_longwave_flux_by_band_in_air_assuming_clear_sky'],
+                diagnostics['air_temperature_tendency_from_longwave_by_band_assuming_clear_sky'],
                 state['longwave_optical_thickness_due_to_cloud'],
                 state['mass_content_of_cloud_ice_in_atmosphere_layer'],
                 state['mass_content_of_cloud_liquid_water_in_atmosphere_layer'],

--- a/climt/_lib/rrtmg_lw/rrtmg_lw_rad.nomcica.f90
+++ b/climt/_lib/rrtmg_lw/rrtmg_lw_rad.nomcica.f90
@@ -78,7 +78,7 @@
 !------------------------------------------------------------------
 
       subroutine rrtmg_lw &
-            (ncol    ,nlay    ,icld    ,idrv    , &
+            (ncol    ,nlay    ,icld    ,idrv    ,icalc_bnds, &
              play    ,plev    ,tlay    ,tlev    ,tsfc    , &
              h2ovmr  ,o3vmr   ,co2vmr  ,ch4vmr  ,n2ovmr  ,o2vmr, &
              cfc11vmr,cfc12vmr,cfc22vmr,ccl4vmr ,emis    , &
@@ -86,6 +86,7 @@
              taucld  ,cicewp  ,cliqwp  ,reice   ,reliq   , &
              tauaer  , &
              uflx    ,dflx    ,hr      ,uflxc   ,dflxc,  hrc, &
+             uflx_bnd,dflx_bnd,hr_bnd  ,uflxc_bnd,dflxc_bnd,  hrc_bnd, &
              duflx_dt,duflxc_dt )
 
 ! -------- Description --------
@@ -195,6 +196,9 @@
                                                       !    0: Normal forward calculation
                                                       !    1: Normal forward calculation with
                                                       !       duflx_dt and duflxc_dt output
+      integer(kind=im), intent(in) :: icalc_bnds      ! Flag for output of fluxes by band
+                                                      !    0: Normal output
+                                                      !    1: Normal and band output
 
       real(kind=rb), intent(in) :: play(:,:)          ! Layer pressures (hPa, mb)
                                                       !    Dimensions: (ncol,nlay)
@@ -291,6 +295,24 @@
                                                       !    Dimensions: (ncol,nlay)
 
 ! ----- Optional Output -----
+      real(kind=rb), intent(out), optional :: uflx_bnd(:,:,:)
+                                                      ! Total sky longwave upward flux by band (W/m2)
+                                                      !    Dimensions: (ncol,nlay+1,nbndlw)
+      real(kind=rb), intent(out), optional :: dflx_bnd(:,:,:)
+                                                      ! Total sky longwave downward flux by band (W/m2)
+                                                      !    Dimensions: (ncol,nlay+1,nbndlw)
+      real(kind=rb), intent(out), optional :: hr_bnd(:,:,:)
+                                                      ! Total sky longwave radiative heating rate by band (K/d)
+                                                      !    Dimensions: (ncol,nlay,nbndlw)
+      real(kind=rb), intent(out), optional :: uflxc_bnd(:,:,:)
+                                                      ! Clear sky longwave upward flux by band (W/m2)
+                                                      !    Dimensions: (ncol,nlay+1,nbndlw)
+      real(kind=rb), intent(out), optional :: dflxc_bnd(:,:,:)
+                                                      ! Clear sky longwave downward flux by band (W/m2)
+                                                      !    Dimensions: (ncol,nlay+1,nbndlw)
+      real(kind=rb), intent(out), optional :: hrc_bnd(:,:,:)
+                                                      ! Clear sky longwave radiative heating rate by band (K/d)
+                                                      !    Dimensions: (ncol,nlay+1,nbndlw)
       real(kind=rb), intent(out), optional :: duflx_dt(:,:)     
                                                       ! change in upward longwave flux (w/m2/k)
                                                       ! with respect to surface temperature
@@ -312,6 +334,7 @@
       integer(kind=im) :: imca                ! flag for mcica [0=off, 1=on]
       integer(kind=im) :: k                   ! layer loop index
       integer(kind=im) :: ig                  ! g-point loop index
+      integer(kind=im) :: iband               ! band index
 
 ! Atmosphere
       real(kind=rb) :: pavel(nlay+1)          ! layer pressures (mb) 
@@ -408,6 +431,22 @@
       real(kind=rb) :: totdclfl(0:nlay+1)     ! clear sky downward longwave flux (w/m2)
       real(kind=rb) :: fnetc(0:nlay+1)        ! clear sky net longwave flux (w/m2)
       real(kind=rb) :: htrc(0:nlay+1)         ! clear sky longwave heating rate (k/day)
+      real(kind=rb) :: totuflux_bnd(0:nlay+1,nbndlw)
+                                              ! upward longwave flux by band (w/m2)
+      real(kind=rb) :: totdflux_bnd(0:nlay+1,nbndlw)
+                                              ! downward longwave flux by band (w/m2)
+      real(kind=rb) :: fnet_bnd(0:nlay+1,nbndlw)
+                                              ! net longwave flux by band (w/m2)
+      real(kind=rb) :: htr_bnd(0:nlay+1,nbndlw)
+                                              ! longwave heating rate by band (k/day)
+      real(kind=rb) :: totuclfl_bnd(0:nlay+1,nbndlw)
+                                              ! clear sky upward longwave flux by band (w/m2)
+      real(kind=rb) :: totdclfl_bnd(0:nlay+1,nbndlw)
+                                              ! clear sky downward longwave flux by band (w/m2)
+      real(kind=rb) :: fnetc_bnd(0:nlay+1,nbndlw)
+                                              ! clear sky net longwave flux by band (w/m2)
+      real(kind=rb) :: htrc_bnd(0:nlay+1,nbndlw)
+                                              ! clear sky longwave heating rate by band (k/day)
       real(kind=rb) :: dtotuflux_dt(0:nlay+1) ! change in upward longwave flux (w/m2/k)
                                               ! with respect to surface temperature
       real(kind=rb) :: dtotuclfl_dt(0:nlay+1) ! change in clear sky upward longwave flux (w/m2/k)
@@ -530,6 +569,8 @@
                   pwvcm, fracs, taut, &
                   totuflux, totdflux, fnet, htr, &
                   totuclfl, totdclfl, fnetc, htrc, &
+                  totuflux_bnd, totdflux_bnd, fnet_bnd, htr_bnd, &
+                  totuclfl_bnd, totdclfl_bnd, fnetc_bnd, htrc_bnd, &
                   idrv, dplankbnd_dt, dtotuflux_dt, dtotuclfl_dt )
         else
            call rtrnmr(nlayers, istart, iend, iout, pz, semiss, ncbands, &
@@ -537,6 +578,8 @@
                   pwvcm, fracs, taut, &
                   totuflux, totdflux, fnet, htr, &
                   totuclfl, totdclfl, fnetc, htrc, &
+                  totuflux_bnd, totdflux_bnd, fnet_bnd, htr_bnd, &
+                  totuclfl_bnd, totdclfl_bnd, fnetc_bnd, htrc_bnd, &
                   idrv, dplankbnd_dt, dtotuflux_dt, dtotuclfl_dt )
         endif
 
@@ -560,6 +603,22 @@
             do k = 0, nlayers
                duflx_dt(iplon,k+1) = dtotuflux_dt(k)
                duflxc_dt(iplon,k+1) = dtotuclfl_dt(k)
+            enddo
+         endif
+
+! If icalc_bnds=1 option is active, transfer fluxes by band to output arrays.
+         if (icalc_bnds .eq. 1) then
+            do iband = istart, iend
+               do k = 0, nlayers
+                  uflx_bnd(iplon,k+1,iband) = totuflux_bnd(k,iband)
+                  dflx_bnd(iplon,k+1,iband) = totdflux_bnd(k,iband)
+                  uflxc_bnd(iplon,k+1,iband) = totuclfl_bnd(k,iband)
+                  dflxc_bnd(iplon,k+1,iband) = totdclfl_bnd(k,iband)
+               enddo
+               do k = 0, nlayers-1
+                  hr_bnd(iplon,k+1,iband) = htr_bnd(k,iband)
+                  hrc_bnd(iplon,k+1,iband) = htrc_bnd(k,iband)
+               enddo
             enddo
          endif
 

--- a/climt/_lib/rrtmg_lw/rrtmg_lw_rtrnmc.f90
+++ b/climt/_lib/rrtmg_lw/rrtmg_lw_rtrnmc.f90
@@ -34,6 +34,8 @@
                         pwvcm, fracs, taut, &
                         totuflux, totdflux, fnet, htr, &
                         totuclfl, totdclfl, fnetc, htrc, &
+                        totuflux_bnd, totdflux_bnd, fnet_bnd, htr_bnd, &
+                        totuclfl_bnd, totdclfl_bnd, fnetc_bnd, htrc_bnd, &
                         idrv, dplankbnd_dt, dtotuflux_dt, dtotuclfl_dt )
 !-----------------------------------------------------------------------------
 !
@@ -113,6 +115,22 @@
                                                       !    Dimensions: (0:nlayers)
       real(kind=rb), intent(out) :: htrc(0:)          ! clear sky longwave heating rate (k/day)
                                                       !    Dimensions: (0:nlayers)
+      real(kind=rb), intent(out) :: totuflux_bnd(0:,:)! upward longwave flux by band (w/m2)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: totdflux_bnd(0:,:)! downward longwave flux by band (w/m2)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: fnet_bnd(0:,:)    ! net longwave flux by band (w/m2)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: htr_bnd(0:,:)     ! longwave heating rate by band (k/day)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: totuclfl_bnd(0:,:)! clear sky upward longwave flux by band (w/m2)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: totdclfl_bnd(0:,:)! clear sky downward longwave flux by band (w/m2)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: fnet_bnd(0:,:)    ! clear sky net longwave flux by band (w/m2)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: htrc_bnd(0:,:)    ! clear sky longwave heating rate by band (k/day)
+                                                      !    Dimensions: (0:nlayers, nbndlw)
       real(kind=rb), intent(out) :: dtotuflux_dt(0:)  ! change in upward longwave flux (w/m2/k)
                                                       ! with respect to surface temperature
                                                       !    Dimensions: (0:nlayers)
@@ -221,6 +239,14 @@
 !    totdclfl                     ! clear sky downward longwave flux (w/m2)
 !    fnetc                        ! clear sky net longwave flux (w/m2)
 !    htrc                         ! clear sky longwave heating rate (k/day)
+!    totuflux_bnd                 ! upward longwave flux by band (w/m2)
+!    totdflux_bnd                 ! downward longwave flux by band (w/m2)
+!    fnet_bnd                     ! net longwave flux by band (w/m2)
+!    htr_bnd                      ! longwave heating rate by band (k/day)
+!    totuclfl_bnd                 ! clear sky upward longwave flux by band (w/m2)
+!    totdclfl_bnd                 ! clear sky downward longwave flux by band (w/m2)
+!    fnetc_bnd                    ! clear sky net longwave flux by band (w/m2)
+!    htrc_bnd                     ! clear sky longwave heating rate by band (k/day)
 !    dtotuflux_dt                 ! change in upward longwave flux (w/m2/k)
 !                                 ! with respect to surface temperature
 !    dtotuclfl_dt                 ! change in clear sky upward longwave flux (w/m2/k)
@@ -261,6 +287,7 @@
          endif
       enddo
 
+! Initialize arrays at surface
       urad(0) = 0.0_rb
       drad(0) = 0.0_rb
       totuflux(0) = 0.0_rb
@@ -269,6 +296,13 @@
       clrdrad(0) = 0.0_rb
       totuclfl(0) = 0.0_rb
       totdclfl(0) = 0.0_rb
+! Initialize arrays at surface by band
+      do ibnd = 1,nbndlw
+         totuflux_bnd(0,ibnd) = 0.0_rb
+         totdflux_bnd(0,ibnd) = 0.0_rb
+         totuclfl_bnd(0,ibnd) = 0.0_rb
+         totdclfl_bnd(0,ibnd) = 0.0_rb
+      enddo
       if (idrv .eq. 1) then
          d_urad_dt(0) = 0.0_rb
          d_clrurad_dt(0) = 0.0_rb
@@ -276,6 +310,7 @@
          dtotuclfl_dt(0) = 0.0_rb
       endif
 
+! Initialize arrays at levels
       do lay = 1, nlayers
          urad(lay) = 0.0_rb
          drad(lay) = 0.0_rb
@@ -285,6 +320,13 @@
          clrdrad(lay) = 0.0_rb
          totuclfl(lay) = 0.0_rb
          totdclfl(lay) = 0.0_rb
+! Initialize arrays at levels by band
+         do ibnd = 1,nbndlw
+            totuflux_bnd(lay,ibnd) = 0.0_rb
+            totdflux_bnd(lay,ibnd) = 0.0_rb
+            totuclfl_bnd(lay,ibnd) = 0.0_rb
+            totdclfl_bnd(lay,ibnd) = 0.0_rb
+         enddo
          icldlyr(lay) = 0
          if (idrv .eq. 1) then
             d_urad_dt(lay) = 0.0_rb
@@ -521,14 +563,20 @@
             dflux(lev) = drad(lev)*wtdiff
             urad(lev) = 0.0_rb
             drad(lev) = 0.0_rb
-            totuflux(lev) = totuflux(lev) + uflux(lev) * delwave(iband)
-            totdflux(lev) = totdflux(lev) + dflux(lev) * delwave(iband)
+! First calculate the fluxes by band.
+            totuflux_bnd(lev,iband) = uflux(lev) * delwave(iband)
+            totdflux_bnd(lev,iband) = dflux(lev) * delwave(iband)
+! Later accumulate them.
+            totuflux(lev) = totuflux(lev) + totuflux_bnd(lev,iband)
+            totdflux(lev) = totdflux(lev) + totdflux_bnd(lev,iband)
             uclfl(lev) = clrurad(lev)*wtdiff
             dclfl(lev) = clrdrad(lev)*wtdiff
             clrurad(lev) = 0.0_rb
             clrdrad(lev) = 0.0_rb
-            totuclfl(lev) = totuclfl(lev) + uclfl(lev) * delwave(iband)
-            totdclfl(lev) = totdclfl(lev) + dclfl(lev) * delwave(iband)
+            totuclfl_bnd(lev,iband) = uclfl(lev) * delwave(iband)
+            totdclfl_bnd(lev,iband) = dclfl(lev) * delwave(iband)
+            totuclfl(lev) = totuclfl(lev) + totuclfl_bnd(lev,iband)
+            totdclfl(lev) = totdclfl(lev) + totdclfl_bnd(lev,iband)
          enddo
 
 ! Calculate total change in upward flux wrt surface temperature
@@ -553,6 +601,15 @@
       totuclfl(0) = totuclfl(0) * fluxfac
       totdclfl(0) = totdclfl(0) * fluxfac
       fnetc(0) = totuclfl(0) - totdclfl(0)
+! Calculate fluxes at surface by band
+      do iband = 1, nbndlw
+         totuflux_bnd(0,iband) = totuflux_bnd(0,iband) * fluxfac
+         totdflux_bnd(0,iband) = totdflux_bnd(0,iband) * fluxfac
+         fnet_bnd(0,iband) = totuflux_bnd(0,iband) - totdflux_bnd(0,iband)
+         totuclfl_bnd(0,iband) = totuclfl_bnd(0,iband) * fluxfac
+         totdclfl_bnd(0,iband) = totdclfl_bnd(0,iband) * fluxfac
+         fnetc_bnd(0,iband) = totuclfl_bnd(0,iband) - totdclfl_bnd(0,iband)
+      enddo
 
 ! Calculate fluxes at model levels
       do lev = 1, nlayers
@@ -562,16 +619,35 @@
          totuclfl(lev) = totuclfl(lev) * fluxfac
          totdclfl(lev) = totdclfl(lev) * fluxfac
          fnetc(lev) = totuclfl(lev) - totdclfl(lev)
+! Calculate fluxes at model levels by band
+         do iband = 1, nbndlw
+            totuflux_bnd(lev,iband) = totuflux_bnd(lev,iband) * fluxfac
+            totdflux_bnd(lev,iband) = totdflux_bnd(lev,iband) * fluxfac
+            fnet_bnd(lev,iband) = totuflux_bnd(lev,iband) - totdflux_bnd(lev,iband)
+            totuclfl_bnd(lev,iband) = totuclfl_bnd(lev,iband) * fluxfac
+            totdclfl_bnd(lev,iband) = totdclfl_bnd(lev,iband) * fluxfac
+            fnetc_bnd(lev,iband) = totuclfl_bnd(lev,iband) - totdclfl_bnd(lev,iband)
+         enddo
          l = lev - 1
 
 ! Calculate heating rates at model layers
          htr(l)=heatfac*(fnet(l)-fnet(lev))/(pz(l)-pz(lev)) 
-         htrc(l)=heatfac*(fnetc(l)-fnetc(lev))/(pz(l)-pz(lev)) 
+         htrc(l)=heatfac*(fnetc(l)-fnetc(lev))/(pz(l)-pz(lev))
+! Calculate heating rates at model layers by band
+         do iband = 1, nbndlw
+            htr_bnd(l,iband)=heatfac*(fnet_bnd(l,iband)-fnet_bnd(lev,iband))/(pz(l)-pz(lev)) 
+            htrc_bnd(l,iband)=heatfac*(fnetc_bnd(l,iband)-fnetc_bnd(lev,iband))/(pz(l)-pz(lev))
+         enddo
       enddo
 
 ! Set heating rate to zero in top layer
       htr(nlayers) = 0.0_rb
       htrc(nlayers) = 0.0_rb
+! Set heating rate to zero in top layer by band
+      do iband = 1, nbndlw
+         htr_bnd(nlayers,iband) = 0.0_rb
+         htrc_bnd(nlayers,iband) = 0.0_rb
+      enddo
 
       end subroutine rtrnmc
 

--- a/climt/_lib/rrtmg_lw/rrtmg_lw_rtrnmr.f90
+++ b/climt/_lib/rrtmg_lw/rrtmg_lw_rtrnmr.f90
@@ -34,6 +34,8 @@
                         pwvcm, fracs, taut, & 
                         totuflux, totdflux, fnet, htr, &
                         totuclfl, totdclfl, fnetc, htrc, &
+                        totuflux_bnd, totdflux_bnd, fnet_bnd, htr_bnd, &
+                        totuclfl_bnd, totdclfl_bnd, fnetc_bnd, htrc_bnd, &
                         idrv, dplankbnd_dt, dtotuflux_dt, dtotuclfl_dt )
 !-----------------------------------------------------------------------------
 !
@@ -112,6 +114,22 @@
                                                       !    Dimensions: (0:nlayers)
       real(kind=rb), intent(out) :: htrc(0:)          ! clear sky longwave heating rate (k/day)
                                                       !    Dimensions: (0:nlayers)
+      real(kind=rb), intent(out) :: totuflux_bnd(0:,:)! upward longwave flux by band (w/m2)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: totdflux_bnd(0:,:)! downward longwave flux by band (w/m2)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: fnet_bnd(0:,:)    ! net longwave flux by band (w/m2)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: htr_bnd(0:,:)     ! longwave heating rate by band (k/day)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: totuclfl_bnd(0:,:)! clear sky upward longwave flux by band (w/m2)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: totdclfl_bnd(0:,:)! clear sky downward longwave flux by band (w/m2)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: fnet_bnd(0:,:)    ! clear sky net longwave flux by band (w/m2)
+                                                      !    Dimensions: (0:nlayers,nbndlw)
+      real(kind=rb), intent(out) :: htrc_bnd(0:,:)    ! clear sky longwave heating rate by band (k/day)
+                                                      !    Dimensions: (0:nlayers, nbndlw)
       real(kind=rb), intent(out) :: dtotuflux_dt(0:)  ! change in upward longwave flux (w/m2/k)
                                                       ! with respect to surface temperature
                                                       !    Dimensions: (0:nlayers)
@@ -234,6 +252,14 @@
 !    totdclfl                     ! clear sky downward longwave flux (w/m2)
 !    fnetc                        ! clear sky net longwave flux (w/m2)
 !    htrc                         ! clear sky longwave heating rate (k/day)
+!    totuflux_bnd                 ! upward longwave flux by band (w/m2)
+!    totdflux_bnd                 ! downward longwave flux by band (w/m2)
+!    fnet_bnd                     ! net longwave flux by band (w/m2)
+!    htr_bnd                      ! longwave heating rate by band (k/day)
+!    totuclfl_bnd                 ! clear sky upward longwave flux by band (w/m2)
+!    totdclfl_bnd                 ! clear sky downward longwave flux by band (w/m2)
+!    fnetc_bnd                    ! clear sky net longwave flux by band (w/m2)
+!    htrc_bnd                     ! clear sky longwave heating rate by band (k/day)
 !    dtotuflux_dt                 ! change in upward longwave flux (w/m2/k)
 !                                 ! with respect to surface temperature
 !    dtotuclfl_dt                 ! change in clear sky upward longwave flux (w/m2/k)
@@ -289,6 +315,13 @@
       clrdrad(0) = 0.0_rb
       totuclfl(0) = 0.0_rb
       totdclfl(0) = 0.0_rb
+! Initialize arrays at surface by band
+      do ibnd = 1,nbndlw
+         totuflux_bnd(0,ibnd) = 0.0_rb
+         totdflux_bnd(0,ibnd) = 0.0_rb
+         totuclfl_bnd(0,ibnd) = 0.0_rb
+         totdclfl_bnd(0,ibnd) = 0.0_rb
+      enddo
       if (idrv .eq. 1) then
          d_urad_dt(0) = 0.0_rb
          d_clrurad_dt(0) = 0.0_rb
@@ -305,6 +338,13 @@
          clrdrad(lay) = 0.0_rb
          totuclfl(lay) = 0.0_rb
          totdclfl(lay) = 0.0_rb
+! Initialize arrays at levels by band
+         do ibnd = 1,nbndlw
+            totuflux_bnd(lay,ibnd) = 0.0_rb
+            totdflux_bnd(lay,ibnd) = 0.0_rb
+            totuclfl_bnd(lay,ibnd) = 0.0_rb
+            totdclfl_bnd(lay,ibnd) = 0.0_rb
+         enddo
          if (idrv .eq. 1) then
             d_urad_dt(lay) = 0.0_rb
             d_clrurad_dt(lay) = 0.0_rb
@@ -722,14 +762,20 @@
             dflux(lev) = drad(lev)*wtdiff
             urad(lev) = 0.0_rb
             drad(lev) = 0.0_rb
-            totuflux(lev) = totuflux(lev) + uflux(lev) * delwave(iband)
-            totdflux(lev) = totdflux(lev) + dflux(lev) * delwave(iband)
+! First calculate the fluxes by band.
+            totuflux_bnd(lev,iband) = uflux(lev) * delwave(iband)
+            totdflux_bnd(lev,iband) = dflux(lev) * delwave(iband)
+! Later accumulate them.
+            totuflux(lev) = totuflux(lev) + totuflux_bnd(lev,iband)
+            totdflux(lev) = totdflux(lev) + totdflux_bnd(lev,iband)
             uclfl(lev) = clrurad(lev)*wtdiff
             dclfl(lev) = clrdrad(lev)*wtdiff
             clrurad(lev) = 0.0_rb
             clrdrad(lev) = 0.0_rb
-            totuclfl(lev) = totuclfl(lev) + uclfl(lev) * delwave(iband)
-            totdclfl(lev) = totdclfl(lev) + dclfl(lev) * delwave(iband)
+            totuclfl_bnd(lev,iband) = uclfl(lev) * delwave(iband)
+            totdclfl_bnd(lev,iband) = dclfl(lev) * delwave(iband)
+            totuclfl(lev) = totuclfl(lev) + totuclfl_bnd(lev,iband)
+            totdclfl(lev) = totdclfl(lev) + totdclfl_bnd(lev,iband)
          enddo
 
 ! Calculate total change in upward flux wrt surface temperature
@@ -752,10 +798,18 @@
       totuflux(0) = totuflux(0) * fluxfac
       totdflux(0) = totdflux(0) * fluxfac
       fnet(0) = totuflux(0) - totdflux(0)
-
       totuclfl(0) = totuclfl(0) * fluxfac
       totdclfl(0) = totdclfl(0) * fluxfac
       fnetc(0) = totuclfl(0) - totdclfl(0)
+! Calculate fluxes at surface by band
+      do iband = 1, nbndlw
+         totuflux_bnd(0,iband) = totuflux_bnd(0,iband) * fluxfac
+         totdflux_bnd(0,iband) = totdflux_bnd(0,iband) * fluxfac
+         fnet_bnd(0,iband) = totuflux_bnd(0,iband) - totdflux_bnd(0,iband)
+         totuclfl_bnd(0,iband) = totuclfl_bnd(0,iband) * fluxfac
+         totdclfl_bnd(0,iband) = totdclfl_bnd(0,iband) * fluxfac
+         fnetc_bnd(0,iband) = totuclfl_bnd(0,iband) - totdclfl_bnd(0,iband)
+      enddo
 
 ! Calculate fluxes at model levels
       do lev = 1, nlayers
@@ -765,16 +819,35 @@
          totuclfl(lev) = totuclfl(lev) * fluxfac
          totdclfl(lev) = totdclfl(lev) * fluxfac
          fnetc(lev) = totuclfl(lev) - totdclfl(lev)
+! Calculate fluxes at model levels by band
+         do iband = 1, nbndlw
+            totuflux_bnd(lev,iband) = totuflux_bnd(lev,iband) * fluxfac
+            totdflux_bnd(lev,iband) = totdflux_bnd(lev,iband) * fluxfac
+            fnet_bnd(lev,iband) = totuflux_bnd(lev,iband) - totdflux_bnd(lev,iband)
+            totuclfl_bnd(lev,iband) = totuclfl_bnd(lev,iband) * fluxfac
+            totdclfl_bnd(lev,iband) = totdclfl_bnd(lev,iband) * fluxfac
+            fnetc_bnd(lev,iband) = totuclfl_bnd(lev,iband) - totdclfl_bnd(lev,iband)
+         enddo
          l = lev - 1
 
 ! Calculate heating rates at model layers
          htr(l)=heatfac*(fnet(l)-fnet(lev))/(pz(l)-pz(lev)) 
-         htrc(l)=heatfac*(fnetc(l)-fnetc(lev))/(pz(l)-pz(lev)) 
+         htrc(l)=heatfac*(fnetc(l)-fnetc(lev))/(pz(l)-pz(lev))
+! Calculate heating rates at model layers by band
+         do iband = 1, nbndlw
+            htr_bnd(l,iband)=heatfac*(fnet_bnd(l,iband)-fnet_bnd(lev,iband))/(pz(l)-pz(lev)) 
+            htrc_bnd(l,iband)=heatfac*(fnetc_bnd(l,iband)-fnetc_bnd(lev,iband))/(pz(l)-pz(lev))
+         enddo
       enddo
 
 ! Set heating rate to zero in top layer
       htr(nlayers) = 0.0_rb
       htrc(nlayers) = 0.0_rb
+! Set heating rate to zero in top layer by band
+      do iband = 1, nbndlw
+         htr_bnd(nlayers,iband) = 0.0_rb
+         htrc_bnd(nlayers,iband) = 0.0_rb
+      enddo
 
       end subroutine rtrnmr
 


### PR DESCRIPTION
- Modified the radiative transfer routines to separate the spectral band
  contributions before integrating them in the net quantity and setting
  them as output
  + modified modules: rrtmg_lw_rtrn.f90, rrtmg_lw_rtrnmr.f90 and
    rrtmg_lw_rtrnmc.f90

- Modified the radiative transfer calling routines with a flag and the
  necessary variables in the call to switch on/off the new calculations.
  + modified modules: rrtmg_lw_rad.nomcica.f90, rrtmg_lw_rad.f90

- Modified the Cython extension to accomodate the new flag and variables.

- Modified the Python component module to include the states, tendencies,
  and diagnostics.