### PR TITLE
fix macos compiling without homebrew gcc at /usr/local/Cellar/gcc*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,16 +128,21 @@ if operating_system == 'Windows':
 os.environ['FFLAGS'] = '-fPIC -fno-range-check ' + os.environ['CLIMT_OPT_FLAGS']
 os.environ['CFLAGS'] = '-fPIC ' + os.environ['CLIMT_OPT_FLAGS']
 
-if operating_system == 'Darwin':
-    gcc_dir = find_homebrew_gcc()
-    # print('gcc_dir', gcc_dir)
-    for root, dirs, files in os.walk(gcc_dir):
-        for line in files:
-            if re.match('libgfortran.a', line):
-                if not ('i386' in root):
-                    lib_path_list.append(root)
+if operating_system == 'Darwin':    # gcc_dir = find_homebrew_gcc()
+    # # print('gcc_dir', gcc_dir)
+    # for root, dirs, files in os.walk(gcc_dir):
+    #     for line in files:
+    #         if re.match("libgfortran.a", line):
+    #             if not ("i386" in root):
+    #                 lib_path_list.append(root)
+    path = subprocess.run(
+        [os.environ["FC"], "--print-file-name", "libgfortran.dylib"],
+        capture_output=True,
+        text=True,
+    ).stdout
+    print(path)
 
-    # print(lib_path_list)
+    lib_path_list.append(os.path.dirname(path))
 
     os.environ['FFLAGS'] += ' -mmacosx-version-min=10.7'
     os.environ['CFLAGS'] += ' -mmacosx-version-min=10.7'


### PR DESCRIPTION
climt was not building on my macos. It was trying to look for gcc at /usr/local/Cellar/gcc, which does not exist on my system. If I missed an install step, please let me know.

To fix, I removed the reference to homebrew and instead get the libgfortran.a file by querying the fortran instance referred to by the "FC" envvar.