### PR TITLE
fix(docs): deployed-site landing-page 404s + legible code blocks

### DIFF
--- a/docs/climt.scss
+++ b/docs/climt.scss
@@ -58,13 +58,14 @@ $navbar-fg:  #34302a;
   background: #fdf6ea;
 }
 
-// Code blocks: warm-dark surface like the DS CodeBlock component.
+// Code blocks: warm light surface matching inline code, so the light-theme
+// syntax-highlight token colors stay legible (a dark surface hid them).
 div.sourceCode {
-  background: #211e1a;
+  background: #f6efe0;            // warm cream, a touch deeper than the page
   border-radius: .75rem;
-  border: 1px solid #34302a;
+  border: 1px solid #e6dcc6;     // hairline sand
 }
-div.sourceCode pre code { color: #f4eee2; }
+div.sourceCode pre code { color: #34302a; }   // warm ink for un-tokenized text
 
 // Rounded, soft-shadow cards for the Experiments listing grid.
 .quarto-grid-item.card {

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -182,9 +182,9 @@ body{padding-top:0!important;margin-top:0!important;}
       <span>climt</span>
     </span>
     <span class="links">
-      <a class="l" href="quickstart.html">Docs</a>
-      <a class="l" href="user-guide.html">User Guide</a>
-      <a class="l" href="experiments.html">Experiments</a>
+      <a class="l" href="get-started/quickstart.html">Docs</a>
+      <a class="l" href="user-guide/introduction.html">User Guide</a>
+      <a class="l" href="experiments/index.html">Experiments</a>
       <a class="l" href="https://github.com/CliMT/climt">GitHub ↗</a>
     </span>
   </nav>
@@ -200,8 +200,8 @@ body{padding-top:0!important;margin-top:0!important;}
         <p class="lead">climt is a Climate Modelling and Diagnostics Toolkit — a modular, intuitive way to write
           numerical models of the climate system. State-of-the-art components, no Fortran required.</p>
         <div class="cta-row">
-          <a class="btn primary" href="quickstart.html">Get started <span>→</span></a>
-          <a class="btn secondary" href="quickstart.html">Read the docs</a>
+          <a class="btn primary" href="get-started/quickstart.html">Get started <span>→</span></a>
+          <a class="btn secondary" href="get-started/quickstart.html">Read the docs</a>
         </div>
         <div class="install">
           <span class="dollar">$</span>
@@ -275,9 +275,9 @@ tendencies, diagnostics = <span class="fn">radiation</span>(state)</code></pre>
       <div class="cols">
         <div>
           <h4>Docs</h4>
-          <a href="quickstart.html">Quickstart</a>
-          <a href="user-guide.html">User Guide</a>
-          <a href="api.html">API Reference</a>
+          <a href="get-started/quickstart.html">Quickstart</a>
+          <a href="user-guide/introduction.html">User Guide</a>
+          <a href="api/index.html">API Reference</a>
         </div>
         <div>
           <h4>Project</h4>
@@ -287,8 +287,8 @@ tendencies, diagnostics = <span class="fn">radiation</span>(state)</code></pre>
         </div>
         <div>
           <h4>Learn</h4>
-          <a href="#">Radiative Transfer</a>
-          <a href="experiments.html">Experiments</a>
+          <a href="radiative-transfer/index.html">Radiative Transfer</a>
+          <a href="experiments/index.html">Experiments</a>
           <a href="#">Citing climt</a>
         </div>
       </div>


### PR DESCRIPTION
Two small post-#215 fixes for the deployed docs site. Merging this redeploys `/dev` with both.

## 1. Landing-page links 404'd
The landing page is a custom `{=html}` block, and Quarto does not rewrite hrefs inside raw HTML, so its hand-written bare filenames (`quickstart.html`, `user-guide.html`, `experiments.html`, `api.html`) shipped pointing at nonexistent site-root files. Repointed to the real pages (`get-started/quickstart.html`, `user-guide/introduction.html`, `experiments/index.html`, `api/index.html`, `radiative-transfer/index.html`); verified all targets exist in the render. (This missed #215 by one commit — that PR merged just before it was pushed.)

## 2. Code blocks were unreadable
Code blocks were forced to a near-black surface (`#211e1a`) while the site uses the light `cosmo` theme, whose syntax-highlight tokens are dark colors meant for light backgrounds — so tokens were nearly invisible. Switched the block surface to warm cream (matching inline code) with a hairline sand border, so the existing token colors read clearly. Verified in a rendered page (browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)