### PR TITLE
ci: skip platform-wheel build and PyPI publish on prereleases

### DIFF
--- a/.github/workflows/release_climt.yml
+++ b/.github/workflows/release_climt.yml
@@ -7,6 +7,9 @@ on:
 jobs:
     build_wheels:
         name: Build wheels on ${{ matrix.os }}
+        # Prereleases (e.g. the in-browser docs demo wheel) must not build the
+        # platform wheels or publish to PyPI. Only build-pure-wheel runs for them.
+        if: ${{ !github.event.release.prerelease }}
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
@@ -53,6 +56,7 @@ jobs:
                   path: dist/
     publish-to-pypi:
         name: Publishing to PyPI
+        if: ${{ !github.event.release.prerelease }}
         needs:
             - build_wheels
         runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Guards the `build_wheels` and `publish-to-pypi` jobs in `release_climt.yml` with:

```yaml
if: ${{ !github.event.release.prerelease }}
```

## Why

We want to host the in-browser docs demo wheel as a **prerelease** GitHub
release (the flagship quarto-live page installs it via `micropip`). But the
release workflow triggers on `release: published` and runs `publish-to-pypi`
(trusted publishing) with no prerelease guard — so cutting a prerelease would
attempt a PyPI publish and burn the full platform-wheel CI matrix.

Since `release`-triggered workflows run the workflow file from the **default
branch**, this guard has to be on `develop` to take effect. With it in place, a
prerelease runs neither `build_wheels` nor `publish-to-pypi`; a real
(non-pre) release is completely unaffected.

Minimal, single-file change — split out of the `feature/pyodide-cork-prep`
branch so it can land ahead of the demo work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)